### PR TITLE
change CI to v1.3.0

### DIFF
--- a/dockerfiles/Dockerfile.amd64_cpu
+++ b/dockerfiles/Dockerfile.amd64_cpu
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
 
 # SOURCE INSTALLATION
 ENV PYTORCH_DIST_DIR /opt/libtorch
-ARG BRANCH=v1.1.0
+ARG BRANCH=v1.3.0
 
 RUN git clone --single-branch --depth=1 --recurse-submodules --branch=${BRANCH} https://github.com/pytorch/pytorch.git && cd pytorch && \
   git submodule update --init && \
@@ -109,7 +109,6 @@ WORKDIR $GOPATH/src/$PKG
 RUN git clone --depth=1 --single-branch --branch=master  https://${PKG}.git .
 
 RUN dep ensure -v -no-vendor -update \
-    github.com/rai-project/go-pytorch \
     github.com/rai-project/dlframework && \
     dep ensure -v -vendor-only
 

--- a/dockerfiles/Dockerfile.amd64_gpu
+++ b/dockerfiles/Dockerfile.amd64_gpu
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
 
 # SOURCE INSTALLATION
 ENV PYTORCH_DIST_DIR /opt/libtorch
-ARG BRANCH=v1.1.0
+ARG BRANCH=v1.3.0
 
 RUN git clone --single-branch --depth=1 --recurse-submodules --branch=${BRANCH} https://github.com/pytorch/pytorch.git && cd pytorch && \
   git submodule update --init && \
@@ -110,7 +110,6 @@ WORKDIR $GOPATH/src/$PKG
 RUN git clone --depth=1 --single-branch --branch=master https://${PKG}.git .
 
 RUN dep ensure -v -no-vendor -update \
-    github.com/rai-project/go-pytorch \
     github.com/rai-project/dlframework && \
     dep ensure -v -vendor-only
 

--- a/lib.go
+++ b/lib.go
@@ -2,7 +2,7 @@ package pytorch
 
 // #cgo CXXFLAGS: -std=c++11 -I${SRCDIR}/cbits -g -O3
 // #cgo CFLAGS: -I${SRCDIR}/cbits -O3 -Wall -Wno-unused-variable -Wno-deprecated-declarations -Wno-c++11-narrowing -g -Wno-sign-compare -Wno-unused-function
-// #cgo LDFLAGS: -lstdc++ -ltorch -lcaffe2_nvrtc -lc10  -lglog
+// #cgo LDFLAGS: -lstdc++ -ltorch -lc10 -lglog
 // #cgo !python CXXFLAGS: -isystem /opt/libtorch/include
 // #cgo !python CXXFLAGS: -isystem /opt/libtorch/include/torch/csrc/api/include
 // #cgo !python CXXFLAGS: -isystem /opt/libtorch/include/torch/csrc


### PR DESCRIPTION
Maintain Dockerfiles and CI to v1.3.0 .
caffe2_nvrtc seems like for GPU only and produce an error when running for CPU, so disable it for CPU.