### PR TITLE
fix profiler

### DIFF
--- a/predictor.cpp
+++ b/predictor.cpp
@@ -32,7 +32,6 @@ class Predictor {
   torch::IValue output_;
   torch::DeviceType mode_{torch::kCPU};
 
-  std::stringstream ss_;
   profile *prof_{nullptr};
   std::string profile_filename_{"profile.trace"};
   bool profile_enabled_{false};
@@ -193,8 +192,11 @@ char *Torch_ProfilingRead(Torch_PredictorContext pred) {
   if (predictor->prof_ == nullptr) {
     return strdup("");
   }
-  const auto prof_output = predictor->ss_.str().c_str();
-  return strdup(prof_output);
+  
+  std::stringstream ss;
+  std::ifstream in(predictor->profile_filename_);
+  ss << in.rdbuf();
+  return strdup(ss.str().c_str());
 
   END_HANDLE_TH_ERRORS(Torch_GlobalError, (char *)0);
 }


### PR DESCRIPTION
pytorch-agent requests the profile as a string instead of a file. To ensure backward compatibility with rai-project/go-pytroch/example, still save the profile as a file and when requested by pytorch-agent, we read from the file and then return the string.

Another method is to add some flags and call autograd::profiler::RecordProfile with stringstream/filename based on the flag but this will need to change many files so I just choose the method above.

NOTE: The original code has a bug when using c_str since the pointer to the c_str is not valid after the statement. This is fixed by directly use the c_str as an argument when calling strdup(c_str) instead of dividing into two steps.